### PR TITLE
For x = 0 it performs the absolute error instead of the relative one

### DIFF
--- a/server/logic/logic_adapter.py
+++ b/server/logic/logic_adapter.py
@@ -40,7 +40,6 @@ def getAllDerivatives(formula, v, n):
     vals = [get_rel_err(newtonValue, trueValue),
             get_rel_err(lanczoValue, trueValue),
             get_rel_err(finiteValue, trueValue)]
-    print(vals)
     return t, vals
 
 

--- a/server/logic/logic_adapter.py
+++ b/server/logic/logic_adapter.py
@@ -14,7 +14,11 @@ def true(expr, value, n):
 
 
 def get_rel_err(v, t):
-    return float(v), float(abs((v - t)/t))
+    if t == 0:
+        rel_err = float(abs(v-t))
+    else:
+        rel_err = float(abs(v-t)/abs(t))
+    return float(v), rel_err
 
 
 def lanczo(expr, value, n):
@@ -36,6 +40,7 @@ def getAllDerivatives(formula, v, n):
     vals = [get_rel_err(newtonValue, trueValue),
             get_rel_err(lanczoValue, trueValue),
             get_rel_err(finiteValue, trueValue)]
+    print(vals)
     return t, vals
 
 


### PR DESCRIPTION
For x = 0 it uses absolute error instead of relative error, if it is possible, we should display a message like that on the front end.
![image](https://user-images.githubusercontent.com/28573612/90456339-bdc25f00-e0c6-11ea-9f74-7fdf017c1d5f.png)
